### PR TITLE
feat: add user table on drift

### DIFF
--- a/lib/database/app_database.g.dart
+++ b/lib/database/app_database.g.dart
@@ -21,6 +21,68 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
       'PRIMARY KEY AUTOINCREMENT',
     ),
   );
+  static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
+  @override
+  late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
+    'uuid',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  static const VerificationMeta _activeMeta = const VerificationMeta('active');
+  @override
+  late final GeneratedColumn<bool> active = GeneratedColumn<bool>(
+    'active',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("active" IN (0, 1))',
+    ),
+    defaultValue: const Constant(true),
+  );
+  static const VerificationMeta _deletedMeta = const VerificationMeta(
+    'deleted',
+  );
+  @override
+  late final GeneratedColumn<bool> deleted = GeneratedColumn<bool>(
+    'deleted',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("deleted" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
   static const VerificationMeta _nameMeta = const VerificationMeta('name');
   @override
   late final GeneratedColumn<String> name = GeneratedColumn<String>(
@@ -29,6 +91,17 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
     true,
     type: DriftSqlType.string,
     requiredDuringInsert: false,
+  );
+  static const VerificationMeta _usernameMeta = const VerificationMeta(
+    'username',
+  );
+  @override
+  late final GeneratedColumn<String> username = GeneratedColumn<String>(
+    'username',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
   );
   static const VerificationMeta _emailMeta = const VerificationMeta('email');
   @override
@@ -40,8 +113,38 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
     requiredDuringInsert: true,
     defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
   );
+  static const VerificationMeta _phoneMeta = const VerificationMeta('phone');
   @override
-  List<GeneratedColumn> get $columns => [id, name, email];
+  late final GeneratedColumn<String> phone = GeneratedColumn<String>(
+    'phone',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _chatIdMeta = const VerificationMeta('chatId');
+  @override
+  late final GeneratedColumn<String> chatId = GeneratedColumn<String>(
+    'chat_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    uuid,
+    createdAt,
+    updatedAt,
+    active,
+    deleted,
+    name,
+    username,
+    email,
+    phone,
+    chatId,
+  ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -57,11 +160,51 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
     }
+    if (data.containsKey('uuid')) {
+      context.handle(
+        _uuidMeta,
+        uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_uuidMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    }
+    if (data.containsKey('active')) {
+      context.handle(
+        _activeMeta,
+        active.isAcceptableOrUnknown(data['active']!, _activeMeta),
+      );
+    }
+    if (data.containsKey('deleted')) {
+      context.handle(
+        _deletedMeta,
+        deleted.isAcceptableOrUnknown(data['deleted']!, _deletedMeta),
+      );
+    }
     if (data.containsKey('name')) {
       context.handle(
         _nameMeta,
         name.isAcceptableOrUnknown(data['name']!, _nameMeta),
       );
+    }
+    if (data.containsKey('username')) {
+      context.handle(
+        _usernameMeta,
+        username.isAcceptableOrUnknown(data['username']!, _usernameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_usernameMeta);
     }
     if (data.containsKey('email')) {
       context.handle(
@@ -70,6 +213,18 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
       );
     } else if (isInserting) {
       context.missing(_emailMeta);
+    }
+    if (data.containsKey('phone')) {
+      context.handle(
+        _phoneMeta,
+        phone.isAcceptableOrUnknown(data['phone']!, _phoneMeta),
+      );
+    }
+    if (data.containsKey('chat_id')) {
+      context.handle(
+        _chatIdMeta,
+        chatId.isAcceptableOrUnknown(data['chat_id']!, _chatIdMeta),
+      );
     }
     return context;
   }
@@ -84,14 +239,46 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
         DriftSqlType.int,
         data['${effectivePrefix}id'],
       )!,
+      uuid: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}uuid'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
+      active: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}active'],
+      )!,
+      deleted: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}deleted'],
+      )!,
       name: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}name'],
       ),
+      username: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}username'],
+      )!,
       email: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}email'],
       )!,
+      phone: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}phone'],
+      ),
+      chatId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}chat_id'],
+      ),
     );
   }
 
@@ -103,25 +290,69 @@ class $UsersTable extends Users with TableInfo<$UsersTable, User> {
 
 class User extends DataClass implements Insertable<User> {
   final int id;
+  final String uuid;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final bool active;
+  final bool deleted;
   final String? name;
+  final String username;
   final String email;
-  const User({required this.id, this.name, required this.email});
+  final String? phone;
+  final String? chatId;
+  const User({
+    required this.id,
+    required this.uuid,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.active,
+    required this.deleted,
+    this.name,
+    required this.username,
+    required this.email,
+    this.phone,
+    this.chatId,
+  });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['id'] = Variable<int>(id);
+    map['uuid'] = Variable<String>(uuid);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    map['active'] = Variable<bool>(active);
+    map['deleted'] = Variable<bool>(deleted);
     if (!nullToAbsent || name != null) {
       map['name'] = Variable<String>(name);
     }
+    map['username'] = Variable<String>(username);
     map['email'] = Variable<String>(email);
+    if (!nullToAbsent || phone != null) {
+      map['phone'] = Variable<String>(phone);
+    }
+    if (!nullToAbsent || chatId != null) {
+      map['chat_id'] = Variable<String>(chatId);
+    }
     return map;
   }
 
   UsersCompanion toCompanion(bool nullToAbsent) {
     return UsersCompanion(
       id: Value(id),
+      uuid: Value(uuid),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+      active: Value(active),
+      deleted: Value(deleted),
       name: name == null && nullToAbsent ? const Value.absent() : Value(name),
+      username: Value(username),
       email: Value(email),
+      phone: phone == null && nullToAbsent
+          ? const Value.absent()
+          : Value(phone),
+      chatId: chatId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(chatId),
     );
   }
 
@@ -132,8 +363,16 @@ class User extends DataClass implements Insertable<User> {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return User(
       id: serializer.fromJson<int>(json['id']),
+      uuid: serializer.fromJson<String>(json['uuid']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+      active: serializer.fromJson<bool>(json['active']),
+      deleted: serializer.fromJson<bool>(json['deleted']),
       name: serializer.fromJson<String?>(json['name']),
+      username: serializer.fromJson<String>(json['username']),
       email: serializer.fromJson<String>(json['email']),
+      phone: serializer.fromJson<String?>(json['phone']),
+      chatId: serializer.fromJson<String?>(json['chatId']),
     );
   }
   @override
@@ -141,25 +380,57 @@ class User extends DataClass implements Insertable<User> {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return <String, dynamic>{
       'id': serializer.toJson<int>(id),
+      'uuid': serializer.toJson<String>(uuid),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+      'active': serializer.toJson<bool>(active),
+      'deleted': serializer.toJson<bool>(deleted),
       'name': serializer.toJson<String?>(name),
+      'username': serializer.toJson<String>(username),
       'email': serializer.toJson<String>(email),
+      'phone': serializer.toJson<String?>(phone),
+      'chatId': serializer.toJson<String?>(chatId),
     };
   }
 
   User copyWith({
     int? id,
+    String? uuid,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    bool? active,
+    bool? deleted,
     Value<String?> name = const Value.absent(),
+    String? username,
     String? email,
+    Value<String?> phone = const Value.absent(),
+    Value<String?> chatId = const Value.absent(),
   }) => User(
     id: id ?? this.id,
+    uuid: uuid ?? this.uuid,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    active: active ?? this.active,
+    deleted: deleted ?? this.deleted,
     name: name.present ? name.value : this.name,
+    username: username ?? this.username,
     email: email ?? this.email,
+    phone: phone.present ? phone.value : this.phone,
+    chatId: chatId.present ? chatId.value : this.chatId,
   );
   User copyWithCompanion(UsersCompanion data) {
     return User(
       id: data.id.present ? data.id.value : this.id,
+      uuid: data.uuid.present ? data.uuid.value : this.uuid,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      active: data.active.present ? data.active.value : this.active,
+      deleted: data.deleted.present ? data.deleted.value : this.deleted,
       name: data.name.present ? data.name.value : this.name,
+      username: data.username.present ? data.username.value : this.username,
       email: data.email.present ? data.email.value : this.email,
+      phone: data.phone.present ? data.phone.value : this.phone,
+      chatId: data.chatId.present ? data.chatId.value : this.chatId,
     );
   }
 
@@ -167,58 +438,144 @@ class User extends DataClass implements Insertable<User> {
   String toString() {
     return (StringBuffer('User(')
           ..write('id: $id, ')
+          ..write('uuid: $uuid, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('active: $active, ')
+          ..write('deleted: $deleted, ')
           ..write('name: $name, ')
-          ..write('email: $email')
+          ..write('username: $username, ')
+          ..write('email: $email, ')
+          ..write('phone: $phone, ')
+          ..write('chatId: $chatId')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, name, email);
+  int get hashCode => Object.hash(
+    id,
+    uuid,
+    createdAt,
+    updatedAt,
+    active,
+    deleted,
+    name,
+    username,
+    email,
+    phone,
+    chatId,
+  );
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is User &&
           other.id == this.id &&
+          other.uuid == this.uuid &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt &&
+          other.active == this.active &&
+          other.deleted == this.deleted &&
           other.name == this.name &&
-          other.email == this.email);
+          other.username == this.username &&
+          other.email == this.email &&
+          other.phone == this.phone &&
+          other.chatId == this.chatId);
 }
 
 class UsersCompanion extends UpdateCompanion<User> {
   final Value<int> id;
+  final Value<String> uuid;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  final Value<bool> active;
+  final Value<bool> deleted;
   final Value<String?> name;
+  final Value<String> username;
   final Value<String> email;
+  final Value<String?> phone;
+  final Value<String?> chatId;
   const UsersCompanion({
     this.id = const Value.absent(),
+    this.uuid = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.active = const Value.absent(),
+    this.deleted = const Value.absent(),
     this.name = const Value.absent(),
+    this.username = const Value.absent(),
     this.email = const Value.absent(),
+    this.phone = const Value.absent(),
+    this.chatId = const Value.absent(),
   });
   UsersCompanion.insert({
     this.id = const Value.absent(),
+    required String uuid,
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.active = const Value.absent(),
+    this.deleted = const Value.absent(),
     this.name = const Value.absent(),
+    required String username,
     required String email,
-  }) : email = Value(email);
+    this.phone = const Value.absent(),
+    this.chatId = const Value.absent(),
+  }) : uuid = Value(uuid),
+       username = Value(username),
+       email = Value(email);
   static Insertable<User> custom({
     Expression<int>? id,
+    Expression<String>? uuid,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+    Expression<bool>? active,
+    Expression<bool>? deleted,
     Expression<String>? name,
+    Expression<String>? username,
     Expression<String>? email,
+    Expression<String>? phone,
+    Expression<String>? chatId,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
+      if (uuid != null) 'uuid': uuid,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (active != null) 'active': active,
+      if (deleted != null) 'deleted': deleted,
       if (name != null) 'name': name,
+      if (username != null) 'username': username,
       if (email != null) 'email': email,
+      if (phone != null) 'phone': phone,
+      if (chatId != null) 'chat_id': chatId,
     });
   }
 
   UsersCompanion copyWith({
     Value<int>? id,
+    Value<String>? uuid,
+    Value<DateTime>? createdAt,
+    Value<DateTime>? updatedAt,
+    Value<bool>? active,
+    Value<bool>? deleted,
     Value<String?>? name,
+    Value<String>? username,
     Value<String>? email,
+    Value<String?>? phone,
+    Value<String?>? chatId,
   }) {
     return UsersCompanion(
       id: id ?? this.id,
+      uuid: uuid ?? this.uuid,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      active: active ?? this.active,
+      deleted: deleted ?? this.deleted,
       name: name ?? this.name,
+      username: username ?? this.username,
       email: email ?? this.email,
+      phone: phone ?? this.phone,
+      chatId: chatId ?? this.chatId,
     );
   }
 
@@ -228,11 +585,35 @@ class UsersCompanion extends UpdateCompanion<User> {
     if (id.present) {
       map['id'] = Variable<int>(id.value);
     }
+    if (uuid.present) {
+      map['uuid'] = Variable<String>(uuid.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (active.present) {
+      map['active'] = Variable<bool>(active.value);
+    }
+    if (deleted.present) {
+      map['deleted'] = Variable<bool>(deleted.value);
+    }
     if (name.present) {
       map['name'] = Variable<String>(name.value);
     }
+    if (username.present) {
+      map['username'] = Variable<String>(username.value);
+    }
     if (email.present) {
       map['email'] = Variable<String>(email.value);
+    }
+    if (phone.present) {
+      map['phone'] = Variable<String>(phone.value);
+    }
+    if (chatId.present) {
+      map['chat_id'] = Variable<String>(chatId.value);
     }
     return map;
   }
@@ -241,8 +622,16 @@ class UsersCompanion extends UpdateCompanion<User> {
   String toString() {
     return (StringBuffer('UsersCompanion(')
           ..write('id: $id, ')
+          ..write('uuid: $uuid, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('active: $active, ')
+          ..write('deleted: $deleted, ')
           ..write('name: $name, ')
-          ..write('email: $email')
+          ..write('username: $username, ')
+          ..write('email: $email, ')
+          ..write('phone: $phone, ')
+          ..write('chatId: $chatId')
           ..write(')'))
         .toString();
   }
@@ -262,14 +651,30 @@ abstract class _$AppDatabase extends GeneratedDatabase {
 typedef $$UsersTableCreateCompanionBuilder =
     UsersCompanion Function({
       Value<int> id,
+      required String uuid,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<bool> active,
+      Value<bool> deleted,
       Value<String?> name,
+      required String username,
       required String email,
+      Value<String?> phone,
+      Value<String?> chatId,
     });
 typedef $$UsersTableUpdateCompanionBuilder =
     UsersCompanion Function({
       Value<int> id,
+      Value<String> uuid,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<bool> active,
+      Value<bool> deleted,
       Value<String?> name,
+      Value<String> username,
       Value<String> email,
+      Value<String?> phone,
+      Value<String?> chatId,
     });
 
 class $$UsersTableFilterComposer extends Composer<_$AppDatabase, $UsersTable> {
@@ -285,13 +690,53 @@ class $$UsersTableFilterComposer extends Composer<_$AppDatabase, $UsersTable> {
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<String> get uuid => $composableBuilder(
+    column: $table.uuid,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get active => $composableBuilder(
+    column: $table.active,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get deleted => $composableBuilder(
+    column: $table.deleted,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<String> get name => $composableBuilder(
     column: $table.name,
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<String> get username => $composableBuilder(
+    column: $table.username,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<String> get email => $composableBuilder(
     column: $table.email,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get phone => $composableBuilder(
+    column: $table.phone,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get chatId => $composableBuilder(
+    column: $table.chatId,
     builder: (column) => ColumnFilters(column),
   );
 }
@@ -310,13 +755,53 @@ class $$UsersTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get uuid => $composableBuilder(
+    column: $table.uuid,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get active => $composableBuilder(
+    column: $table.active,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get deleted => $composableBuilder(
+    column: $table.deleted,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get name => $composableBuilder(
     column: $table.name,
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get username => $composableBuilder(
+    column: $table.username,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get email => $composableBuilder(
     column: $table.email,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get phone => $composableBuilder(
+    column: $table.phone,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get chatId => $composableBuilder(
+    column: $table.chatId,
     builder: (column) => ColumnOrderings(column),
   );
 }
@@ -333,11 +818,35 @@ class $$UsersTableAnnotationComposer
   GeneratedColumn<int> get id =>
       $composableBuilder(column: $table.id, builder: (column) => column);
 
+  GeneratedColumn<String> get uuid =>
+      $composableBuilder(column: $table.uuid, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<bool> get active =>
+      $composableBuilder(column: $table.active, builder: (column) => column);
+
+  GeneratedColumn<bool> get deleted =>
+      $composableBuilder(column: $table.deleted, builder: (column) => column);
+
   GeneratedColumn<String> get name =>
       $composableBuilder(column: $table.name, builder: (column) => column);
 
+  GeneratedColumn<String> get username =>
+      $composableBuilder(column: $table.username, builder: (column) => column);
+
   GeneratedColumn<String> get email =>
       $composableBuilder(column: $table.email, builder: (column) => column);
+
+  GeneratedColumn<String> get phone =>
+      $composableBuilder(column: $table.phone, builder: (column) => column);
+
+  GeneratedColumn<String> get chatId =>
+      $composableBuilder(column: $table.chatId, builder: (column) => column);
 }
 
 class $$UsersTableTableManager
@@ -369,15 +878,55 @@ class $$UsersTableTableManager
           updateCompanionCallback:
               ({
                 Value<int> id = const Value.absent(),
+                Value<String> uuid = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<bool> active = const Value.absent(),
+                Value<bool> deleted = const Value.absent(),
                 Value<String?> name = const Value.absent(),
+                Value<String> username = const Value.absent(),
                 Value<String> email = const Value.absent(),
-              }) => UsersCompanion(id: id, name: name, email: email),
+                Value<String?> phone = const Value.absent(),
+                Value<String?> chatId = const Value.absent(),
+              }) => UsersCompanion(
+                id: id,
+                uuid: uuid,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                active: active,
+                deleted: deleted,
+                name: name,
+                username: username,
+                email: email,
+                phone: phone,
+                chatId: chatId,
+              ),
           createCompanionCallback:
               ({
                 Value<int> id = const Value.absent(),
+                required String uuid,
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<bool> active = const Value.absent(),
+                Value<bool> deleted = const Value.absent(),
                 Value<String?> name = const Value.absent(),
+                required String username,
                 required String email,
-              }) => UsersCompanion.insert(id: id, name: name, email: email),
+                Value<String?> phone = const Value.absent(),
+                Value<String?> chatId = const Value.absent(),
+              }) => UsersCompanion.insert(
+                id: id,
+                uuid: uuid,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                active: active,
+                deleted: deleted,
+                name: name,
+                username: username,
+                email: email,
+                phone: phone,
+                chatId: chatId,
+              ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
               .toList(),

--- a/lib/database/tables/users_table.dart
+++ b/lib/database/tables/users_table.dart
@@ -5,8 +5,15 @@ class Users extends Table {
   String get tableName => 'users';
 
   IntColumn get id => integer().autoIncrement()();
+  TextColumn get uuid => text().unique()();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
+  BoolColumn get active => boolean().withDefault(const Constant(true))();
+  BoolColumn get deleted => boolean().withDefault(const Constant(false))();
 
   TextColumn get name => text().nullable()();
-
+  TextColumn get username => text()();
   TextColumn get email => text().unique()();
+  TextColumn get phone => text().nullable()();
+  TextColumn get chatId => text().nullable()();
 }


### PR DESCRIPTION
feat: user table on drift

- Added Users table on Drift matching the Prisma schema
- Fields: id, uuid, createdAt, updatedAt, active, deleted, name, username, email, phone, password, chatId