### PR TITLE
fix: remove 404 from login error handling

### DIFF
--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -43,7 +43,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       final statusCode = err.response?.statusCode;
 
       String message;
-      if (statusCode == 401 || statusCode == 404) {
+      if (statusCode == 401) {
         message = 'As credenciais estão erradas.';
       } else {
         message = 'Erro ao fazer login.';


### PR DESCRIPTION
fix: remove 404 from login error handling

- Removed 404 status code from login error handling
- Now only 401 is treated as invalid credentials
- Reflects backend change where NotFoundException was replaced by UnauthorizedException