### PR TITLE
feat: add password recovery screens with OTP validation

### DIFF
--- a/lib/features/auth/screens/forgot_password_screen.dart
+++ b/lib/features/auth/screens/forgot_password_screen.dart
@@ -1,0 +1,164 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kronos_app/features/auth/providers/auth_provider.dart';
+
+import 'package:kronos_app/features/auth/screens/validate_otp_screen.dart';
+
+class ForgotPasswordScreen extends ConsumerStatefulWidget {
+  const ForgotPasswordScreen({super.key});
+
+  @override
+  ConsumerState<ForgotPasswordScreen> createState() =>
+      _ForgotPasswordScreenState();
+}
+
+class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _forgotPassword() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    try {
+      final authSerice = ref.read(authServiceProvider);
+
+      await authSerice.forgotPassword(email: _emailController.text);
+
+      if (!mounted) return;
+
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => ValidateOtpScreen(email: _emailController.text),
+        ),
+      );
+
+    } on DioException catch (err) {
+      if (!mounted) return;
+
+      final message = err.response?.data['message'] ?? 'Erro ao enviar código';
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(message)));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 24),
+            child: SizedBox(
+              width: double.infinity,
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    SizedBox(height: MediaQuery.of(context).size.height * 0.30),
+                    Text(
+                      'RECUPERAR SENHA',
+                      style: TextStyle(
+                        fontSize: 28,
+                        fontWeight: FontWeight.bold,
+                        letterSpacing: 4,
+                      ),
+                    ),
+                    SizedBox(height: 8),
+                    Text(
+                      'Digite seu email para receber o código',
+                      style: TextStyle(fontSize: 14, color: Color(0xFF9B9BB5)),
+                    ),
+                    SizedBox(height: 40),
+                    TextFormField(
+                      controller: _emailController,
+                      keyboardType: TextInputType.emailAddress,
+                      decoration: InputDecoration(hintText: "Email"),
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'Email é obrigatório';
+                        }
+                        if (!value.contains('@') || !value.contains('.')) {
+                          return 'Email inválido';
+                        }
+                        return null;
+                      },
+                    ),
+                    SizedBox(height: 32),
+                    Container(
+                      width: double.infinity,
+                      height: 56,
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          colors: [Color(0xFF4A90D9), Color(0xFF7B2FBE)],
+                        ),
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: ElevatedButton(
+                        onPressed: _forgotPassword,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.transparent,
+                          shadowColor: Colors.transparent,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadiusGeometry.circular(16),
+                          ),
+                        ),
+                        child: Text(
+                          'Enviar Código',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: 24),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          'Lembrou a senha? ',
+                          style: TextStyle(
+                            color: Color(0xFF9B9BB5),
+                            fontSize: 14,
+                          ),
+                        ),
+                        GestureDetector(
+                          onTap: () => Navigator.pop(context),
+                          child: ShaderMask(
+                            shaderCallback: (bounds) => LinearGradient(
+                              colors: [Color(0xFF4A90D9), Color(0xFF7B2FBE)],
+                            ).createShader(bounds),
+                            child: Text(
+                              'Voltar ao login',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 14,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    SizedBox(height: 32),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kronos_app/features/auth/providers/auth_provider.dart';
+import 'package:kronos_app/features/auth/screens/forgot_password_screen.dart';
 
 import 'package:kronos_app/features/auth/screens/register_screen.dart';
 import 'package:kronos_app/shared/services/storage_provider.dart';
@@ -44,7 +45,6 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           builder: (context) => HomeScreen()
         ),
       );
-
     } on DioException catch (err) {
       if (!mounted) return;
 
@@ -193,7 +193,14 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                     Align(
                       alignment: Alignment.centerRight,
                       child: TextButton(
-                        onPressed: () {},
+                        onPressed: () {
+                          Navigator.push(
+                            context, 
+                            MaterialPageRoute(
+                              builder: (context) => ForgotPasswordScreen(),
+                            ),
+                          );
+                        },
                         child: Text(
                           'Esqueci minha senha',
                           style: TextStyle(

--- a/lib/features/auth/screens/reset_password_screen.dart
+++ b/lib/features/auth/screens/reset_password_screen.dart
@@ -1,0 +1,202 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kronos_app/features/auth/providers/auth_provider.dart';
+import 'package:kronos_app/features/auth/screens/login_screen.dart';
+
+class ResetPasswordScreen extends ConsumerStatefulWidget {
+  final String email;
+  const ResetPasswordScreen({super.key, required this.email});
+
+  @override
+  ConsumerState<ResetPasswordScreen> createState() =>
+      _ResetPasswordScreenState();
+}
+
+class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+
+  bool _showPassword = false;
+  bool _showConfirmPassword = false;
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _resetPassword() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    if (_passwordController.text != _confirmPasswordController.text) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('As senhas precisam ser iguais.')));
+      return;
+    }
+
+    try {
+      final authService = ref.read(authServiceProvider);
+
+      await authService.resetPassword(
+        email: widget.email,
+        password: _passwordController.text,
+      );
+
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Senha atualizada com sucesso',
+          )
+        )
+      );
+
+      Navigator.pushAndRemoveUntil(
+        context,
+        MaterialPageRoute(builder: (context) => LoginScreen()),
+        (route) => false,
+      );
+
+    } on DioException catch (err) {
+      if (!mounted) return;
+
+      final message = err.response?.data['message'] ?? 'Erro ao alterar senha.';
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(
+        SnackBar(
+          content: Text(
+            message
+          )
+        )
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 24),
+            child: SizedBox(
+              width: double.infinity,
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    SizedBox(height: MediaQuery.of(context).size.height * 0.30),
+                    Text(
+                      'NOVA SENHA',
+                      style: TextStyle(
+                        fontSize: 28,
+                        fontWeight: FontWeight.bold,
+                        letterSpacing: 4,
+                      ),
+                    ),
+                    SizedBox(height: 8),
+                    Text(
+                      'Digite sua nova senha',
+                      style: TextStyle(fontSize: 14, color: Color(0xFF9B9BB5)),
+                    ),
+                    SizedBox(height: 40),
+                    TextFormField(
+                      controller: _passwordController,
+                      obscureText: !_showPassword,
+                      decoration: InputDecoration(
+                        hintText: 'Nova Senha',
+                        suffixIcon: IconButton(
+                          onPressed: () =>
+                              setState(() => _showPassword = !_showPassword),
+                          icon: Icon(
+                            _showPassword
+                                ? Icons.visibility_off
+                                : Icons.visibility,
+                            color: Color(0xFF9B9BB5),
+                          ),
+                        ),
+                      ),
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'Senha é obrigatória';
+                        }
+                        if (value.length < 6) {
+                          return 'A senha deve ter no mínimo 6 caracteres';
+                        }
+                        return null;
+                      },
+                    ),
+                    SizedBox(height: 16),
+                    TextFormField(
+                      controller: _confirmPasswordController,
+                      obscureText: !_showConfirmPassword,
+                      decoration: InputDecoration(
+                        hintText: 'Confirmar nova senha',
+                        suffixIcon: IconButton(
+                          onPressed: () => setState(
+                            () => _showConfirmPassword = !_showConfirmPassword,
+                          ),
+                          icon: Icon(
+                            _showConfirmPassword
+                                ? Icons.visibility_off
+                                : Icons.visibility,
+                            color: Color(0xFF9B9BB5),
+                          ),
+                        ),
+                      ),
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'Confirmação de senha é obrigatória';
+                        }
+                        return null;
+                      },
+                    ),
+                    SizedBox(height: 16),
+                    Container(
+                      width: double.infinity,
+                      height: 56,
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          colors: [Color(0xFF4A90D9), Color(0xFF7B2FBE)],
+                        ),
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: ElevatedButton(
+                        onPressed: _resetPassword,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.transparent,
+                          shadowColor: Colors.transparent,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadiusGeometry.circular(16),
+                          ),
+                        ),
+                        child: Text(
+                          'Salvar nova senha',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: 32),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/screens/validate_otp_screen.dart
+++ b/lib/features/auth/screens/validate_otp_screen.dart
@@ -1,0 +1,150 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kronos_app/features/auth/providers/auth_provider.dart';
+
+import 'package:kronos_app/features/auth/screens/reset_password_screen.dart';
+
+class ValidateOtpScreen extends ConsumerStatefulWidget {
+  final String email;
+  const ValidateOtpScreen({super.key, required this.email});
+
+  @override
+  ConsumerState<ValidateOtpScreen> createState() => _ValidateOtpScreenState();
+}
+
+class _ValidateOtpScreenState extends ConsumerState<ValidateOtpScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _codeController = TextEditingController();
+
+  @override
+  void dispose() {
+    _codeController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _validateOtp() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    try {
+      final authService = ref.read(authServiceProvider);
+
+      await authService.validateOtp(
+        email: widget.email, code: _codeController.text,
+      );
+
+      if(!mounted) return;
+
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => ResetPasswordScreen(email: widget.email)
+        ),
+      );
+
+    } on DioException catch (err) {
+      if (!mounted) return;
+
+      final statusCode = err.response?.statusCode;
+
+      String message;
+      if (statusCode == 400) {
+        message = err.response?.data['message'] ?? 'Código inválido';
+      } else {
+        message = 'Erro ao validar código';
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(message),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 24),
+            child: SizedBox(
+              width: double.infinity,
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    SizedBox(height: MediaQuery.of(context).size.height * 0.30),
+                    Text(
+                      'VERIFICAR CÓDIGO',
+                      style: TextStyle(
+                        fontSize: 28,
+                        fontWeight: FontWeight.bold,
+                        letterSpacing: 4,
+                      ),
+                    ),
+                    SizedBox(height: 8),
+                    Text(
+                      'Digite o código enviado para ${widget.email}',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(fontSize: 14, color: Color(0xFF9B9BB5)),
+                    ),
+                    SizedBox(height: 40),
+                    TextFormField(
+                      controller: _codeController,
+                      keyboardType: TextInputType.number,
+                      decoration: InputDecoration(
+                        hintText: 'Código de 6 dígitos',
+                      ),
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'Código é obrigatório';
+                        }
+                        if (value.length != 6) {
+                          return 'O código deve ter 6 dígitos';
+                        }
+                        return null;
+                      },
+                    ),
+                    SizedBox(height: 32),
+                    Container(
+                      width: double.infinity,
+                      height: 56,
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          colors: [Color(0xFF4A90D9), Color(0xFF7B2FBE)],
+                        ),
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: ElevatedButton(
+                        onPressed: _validateOtp,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.transparent,
+                          shadowColor: Colors.transparent,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadiusGeometry.circular(16),
+                          ),
+                        ),
+                        child: Text(
+                          'Verificar código',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: 32),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/services/auth_service.dart
+++ b/lib/features/auth/services/auth_service.dart
@@ -36,4 +36,37 @@ class AuthService {
 
     return response.data;
   }
+
+  Future<void> forgotPassword({required String email}) async {
+    await _apiService.client.post(
+      '/auth/forgot-password',
+      data: {'email': email}
+    );
+  }
+
+  Future<void> validateOtp({
+    required String email,
+    required String code
+  }) async {
+    await _apiService.client.post(
+      '/auth/validate-otp',
+      data: {
+        'email': email,
+        'code': code
+      }
+    );
+  }
+
+  Future<void> resetPassword({
+    required String email,
+    required String password,
+  }) async {
+    await _apiService.client.post(
+      '/auth/reset-password',
+      data: {
+        'email': email,
+        'password': password,
+      }
+    );
+  }
 }


### PR DESCRIPTION
feat: password recovery screens

- Added ForgotPasswordScreen with email input and API integration
- Added ValidateOtpScreen to validate 6-digit OTP code
- Added ResetPasswordScreen with new password and confirmation fields
- Email is passed between screens via constructor parameters
- Navigator.pushAndRemoveUntil on success to prevent going back to recovery screens
- Connected "Esqueci minha senha" button on LoginScreen to ForgotPasswordScreen
- Error handling with user-friendly messages in Portuguese