### PR TITLE
feat: add responsiveness with flutter_screenutil

### DIFF
--- a/lib/features/auth/screens/forgot_password_screen.dart
+++ b/lib/features/auth/screens/forgot_password_screen.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:kronos_app/features/auth/providers/auth_provider.dart';
 
 import 'package:kronos_app/features/auth/screens/validate_otp_screen.dart';
@@ -56,7 +57,7 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
       body: SafeArea(
         child: SingleChildScrollView(
           child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 24),
+            padding: EdgeInsets.symmetric(horizontal: 24.w),
             child: SizedBox(
               width: double.infinity,
               child: Form(
@@ -68,17 +69,17 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
                     Text(
                       'RECUPERAR SENHA',
                       style: TextStyle(
-                        fontSize: 28,
+                        fontSize: 28.sp,
                         fontWeight: FontWeight.bold,
                         letterSpacing: 4,
                       ),
                     ),
-                    SizedBox(height: 8),
+                    SizedBox(height: 8.h),
                     Text(
                       'Digite seu email para receber o código',
-                      style: TextStyle(fontSize: 14, color: Color(0xFF9B9BB5)),
+                      style: TextStyle(fontSize: 14.sp, color: Color(0xFF9B9BB5)),
                     ),
-                    SizedBox(height: 40),
+                    SizedBox(height: 40.h),
                     TextFormField(
                       controller: _emailController,
                       keyboardType: TextInputType.emailAddress,
@@ -93,15 +94,15 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
                         return null;
                       },
                     ),
-                    SizedBox(height: 32),
+                    SizedBox(height: 32.h),
                     Container(
                       width: double.infinity,
-                      height: 56,
+                      height: 56.h,
                       decoration: BoxDecoration(
                         gradient: LinearGradient(
                           colors: [Color(0xFF4A90D9), Color(0xFF7B2FBE)],
                         ),
-                        borderRadius: BorderRadius.circular(16),
+                        borderRadius: BorderRadius.circular(16.r),
                       ),
                       child: ElevatedButton(
                         onPressed: _forgotPassword,
@@ -109,20 +110,20 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
                           backgroundColor: Colors.transparent,
                           shadowColor: Colors.transparent,
                           shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadiusGeometry.circular(16),
+                            borderRadius: BorderRadiusGeometry.circular(16.r),
                           ),
                         ),
                         child: Text(
                           'Enviar Código',
                           style: TextStyle(
-                            fontSize: 16,
+                            fontSize: 16.sp,
                             fontWeight: FontWeight.bold,
                             color: Colors.white,
                           ),
                         ),
                       ),
                     ),
-                    SizedBox(height: 24),
+                    SizedBox(height: 24.h),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
@@ -130,7 +131,7 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
                           'Lembrou a senha? ',
                           style: TextStyle(
                             color: Color(0xFF9B9BB5),
-                            fontSize: 14,
+                            fontSize: 14.sp,
                           ),
                         ),
                         GestureDetector(
@@ -143,7 +144,7 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
                               'Voltar ao login',
                               style: TextStyle(
                                 color: Colors.white,
-                                fontSize: 14,
+                                fontSize: 14.sp,
                                 fontWeight: FontWeight.w600,
                               ),
                             ),
@@ -151,7 +152,7 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
                         ),
                       ],
                     ),
-                    SizedBox(height: 32),
+                    SizedBox(height: 32.h),
                   ],
                 ),
               ),

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:kronos_app/features/auth/providers/auth_provider.dart';
 import 'package:kronos_app/features/auth/screens/forgot_password_screen.dart';
 
@@ -148,7 +149,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       body: SafeArea(
         child: SingleChildScrollView(
           child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 24),
+            padding: EdgeInsets.symmetric(horizontal: 24.w),
             child: SizedBox(
               width: double.infinity,
               child: Form(
@@ -160,33 +161,33 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                     Column(
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        SizedBox(height: 30),
+                        SizedBox(height: 30.h),
                         Image.asset(
                           'assets/images/kronos_logo.png',
-                          width: 150,
-                          height: 150,
+                          width: 150.w,
+                          height: 150.h,
                         ),
-                        SizedBox(height: 10),
+                        SizedBox(height: 10.h),
                         Text(
                           'KRONOS',
                           style: TextStyle(
-                            fontSize: 28,
+                            fontSize: 28.sp,
                             fontWeight: FontWeight.bold,
                             letterSpacing: 4,
                           ),
                         ),
-                        SizedBox(height: 4),
+                        SizedBox(height: 4.h),
                         Text(
                           'Seu tempo, sua forma',
                           style: TextStyle(
-                            fontSize: 14,
+                            fontSize: 14.sp,
                             color: Color(0xFF9B9BB5),
                           ),
                         ),
                       ],
                     ),
 
-                    SizedBox(height: 40),
+                    SizedBox(height: 40.h),
                     TextFormField(
                       controller: _emailController,
                       keyboardType: TextInputType.emailAddress,
@@ -203,7 +204,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                       },
                     ),
 
-                    SizedBox(height: 16),
+                    SizedBox(height: 16.h),
                     TextFormField(
                       controller: _passwordController,
                       obscureText: !_showPassword,
@@ -232,10 +233,10 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                       },
                     ),
 
-                    SizedBox(height: 32),
+                    SizedBox(height: 32.h),
                     Container(
                       width: double.infinity,
-                      height: 56,
+                      height: 56.h,
                       decoration: BoxDecoration(
                         gradient: LinearGradient(
                           colors: [Color(0xFF4A90D9), Color(0xFF7B2FBE)],
@@ -254,7 +255,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                         child: Text(
                           'Entrar',
                           style: TextStyle(
-                            fontSize: 16,
+                            fontSize: 16.sp,
                             fontWeight: FontWeight.bold,
                             color: Colors.white,
                           ),
@@ -277,7 +278,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                           'Esqueci minha senha',
                           style: TextStyle(
                             color: Color(0xFF9B9BB5),
-                            fontSize: 13,
+                            fontSize: 13.sp,
                           ),
                         ),
                       ),
@@ -287,12 +288,12 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                       children: [
                         Expanded(child: Divider(color: Color(0xFF2A2A4A))),
                         Padding(
-                          padding: EdgeInsets.symmetric(horizontal: 16),
+                          padding: EdgeInsets.symmetric(horizontal: 16.w),
                           child: Text(
                             'ou',
                             style: TextStyle(
                               color: Color(0xFF9B9BB5),
-                              fontSize: 13,
+                              fontSize: 13.sp,
                             ),
                           ),
                         ),
@@ -300,10 +301,10 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                       ],
                     ),
 
-                    SizedBox(height: 16),
+                    SizedBox(height: 16.sp),
                     SizedBox(
                       width: double.infinity,
-                      height: 56,
+                      height: 56.h,
                       child: OutlinedButton.icon(
                         onPressed: _googleSignIn,
                         style: OutlinedButton.styleFrom(
@@ -314,21 +315,21 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                         ),
                         icon: Image.asset(
                           'assets/images/google_logo.png',
-                          width: 24,
-                          height: 24,
+                          width: 24.w,
+                          height: 24.h,
                         ),
                         label: Text(
                           'Entrar com o Google',
                           style: TextStyle(
                             color: Colors.white,
-                            fontSize: 16,
+                            fontSize: 16.sp,
                             fontWeight: FontWeight.w500,
                           ),
                         ),
                       ),
                     ),
 
-                    SizedBox(height: 24),
+                    SizedBox(height: 24.h),
 
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -337,7 +338,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                           'Não tem uma conta? ',
                           style: TextStyle(
                             color: Color(0xFF9B9BB5),
-                            fontSize: 14,
+                            fontSize: 14.sp,
                           ),
                         ),
                         GestureDetector(
@@ -357,7 +358,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                               'Criar conta',
                               style: TextStyle(
                                 color: Colors.white,
-                                fontSize: 14,
+                                fontSize: 14.sp,
                                 fontWeight: FontWeight.w600,
                               ),
                             ),

--- a/lib/features/auth/screens/register_screen.dart
+++ b/lib/features/auth/screens/register_screen.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:kronos_app/features/auth/providers/auth_provider.dart';
 
 import 'package:kronos_app/features/auth/screens/login_screen.dart';
@@ -153,7 +154,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
       body: SafeArea(
         child: SingleChildScrollView(
           child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 24),
+            padding: EdgeInsets.symmetric(horizontal: 24.w),
             child: SizedBox(
               width: double.infinity,
               child: Form(
@@ -165,17 +166,17 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                     Column(
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        SizedBox(height: 30),
+                        SizedBox(height: 30.h),
                         Text(
                           'CADASTRO',
                           style: TextStyle(
-                            fontSize: 28,
+                            fontSize: 28.sp,
                             fontWeight: FontWeight.bold,
                             letterSpacing: 4,
                           ),
                         ),
 
-                        SizedBox(height: 40),
+                        SizedBox(height: 40.h),
                         TextFormField(
                           controller: _nameController,
                           keyboardType: TextInputType.name,
@@ -188,7 +189,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                           },
                         ),
 
-                        SizedBox(height: 16),
+                        SizedBox(height: 16.h),
                         TextFormField(
                           controller: _usernameController,
                           keyboardType: TextInputType.name,
@@ -203,7 +204,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                           },
                         ),
 
-                        SizedBox(height: 16),
+                        SizedBox(height: 16.h),
                         TextFormField(
                           controller: _emailController,
                           keyboardType: TextInputType.emailAddress,
@@ -219,7 +220,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                           },
                         ),
 
-                        SizedBox(height: 16),
+                        SizedBox(height: 16.h),
                         TextFormField(
                           controller: _passwordController,
                           obscureText: !_showPassword,
@@ -248,7 +249,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                           },
                         ),
 
-                        SizedBox(height: 16),
+                        SizedBox(height: 16.h),
                         TextFormField(
                           controller: _confirmPasswordController,
                           obscureText: !_showConfirmPassword,
@@ -275,15 +276,15 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                           },
                         ),
 
-                        SizedBox(height: 32),
+                        SizedBox(height: 32.h),
                         Container(
                           width: double.infinity,
-                          height: 56,
+                          height: 56.h,
                           decoration: BoxDecoration(
                             gradient: LinearGradient(
                               colors: [Color(0xFF4A90D9), Color(0xFF7B2FBE)],
                             ),
-                            borderRadius: BorderRadius.circular(16),
+                            borderRadius: BorderRadius.circular(16.r),
                           ),
                           child: ElevatedButton(
                             onPressed: _register,
@@ -291,13 +292,13 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                               backgroundColor: Colors.transparent,
                               shadowColor: Colors.transparent,
                               shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadiusGeometry.circular(16),
+                                borderRadius: BorderRadiusGeometry.circular(16.r),
                               ),
                             ),
                             child: Text(
                               'Criar conta',
                               style: TextStyle(
-                                fontSize: 16,
+                                fontSize: 16.sp,
                                 fontWeight: FontWeight.bold,
                                 color: Colors.white,
                               ),
@@ -305,18 +306,18 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                           ),
                         ),
 
-                        SizedBox(height: 24),
+                        SizedBox(height: 24.h),
 
                         Row(
                           children: [
                             Expanded(child: Divider(color: Color(0xFF2A2A4A))),
                             Padding(
-                              padding: EdgeInsets.symmetric(horizontal: 16),
+                              padding: EdgeInsets.symmetric(horizontal: 16.w),
                               child: Text(
                                 'ou',
                                 style: TextStyle(
                                   color: Color(0xFF9B9BB5),
-                                  fontSize: 13,
+                                  fontSize: 13.sp,
                                 ),
                               ),
                             ),
@@ -324,35 +325,35 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                           ],
                         ),
 
-                        SizedBox(height: 16),
+                        SizedBox(height: 16.h),
                         SizedBox(
                           width: double.infinity,
-                          height: 56,
+                          height: 56.h,
                           child: OutlinedButton.icon(
                             onPressed: _googleSignIn,
                             style: OutlinedButton.styleFrom(
                               side: BorderSide(color: Color(0xFF2A2A4A)),
                               shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(16),
+                                borderRadius: BorderRadius.circular(16.r),
                               ),
                             ),
                             icon: Image.asset(
                               'assets/images/google_logo.png',
-                              width: 24,
-                              height: 24,
+                              width: 24.w,
+                              height: 24.h,
                             ),
                             label: Text(
                               'Cadastrar com o Google',
                               style: TextStyle(
                                 color: Colors.white,
-                                fontSize: 16,
+                                fontSize: 16.sp,
                                 fontWeight: FontWeight.w500,
                               ),
                             ),
                           ),
                         ),
 
-                        SizedBox(height: 24),
+                        SizedBox(height: 24.h),
 
                         Row(
                           mainAxisAlignment: MainAxisAlignment.center,
@@ -361,7 +362,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                               'Já tem uma conta? ',
                               style: TextStyle(
                                 color: Color(0xFF9B9BB5),
-                                fontSize: 14,
+                                fontSize: 14.sp,
                               ),
                             ),
                             GestureDetector(
@@ -384,7 +385,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                                   'Login',
                                   style: TextStyle(
                                     color: Colors.white,
-                                    fontSize: 14,
+                                    fontSize: 14.sp,
                                     fontWeight: FontWeight.w600,
                                   ),
                                 ),
@@ -392,7 +393,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                             ),
                           ],
                         ),
-                        SizedBox(height: 32),
+                        SizedBox(height: 32.h),
                       ],
                     ),
                   ],

--- a/lib/features/auth/screens/reset_password_screen.dart
+++ b/lib/features/auth/screens/reset_password_screen.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:kronos_app/features/auth/providers/auth_provider.dart';
 import 'package:kronos_app/features/auth/screens/login_screen.dart';
 
@@ -86,7 +87,7 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
       body: SafeArea(
         child: SingleChildScrollView(
           child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 24),
+            padding: EdgeInsets.symmetric(horizontal: 24.w),
             child: SizedBox(
               width: double.infinity,
               child: Form(
@@ -98,17 +99,17 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
                     Text(
                       'NOVA SENHA',
                       style: TextStyle(
-                        fontSize: 28,
+                        fontSize: 28.sp,
                         fontWeight: FontWeight.bold,
                         letterSpacing: 4,
                       ),
                     ),
-                    SizedBox(height: 8),
+                    SizedBox(height: 8.h),
                     Text(
                       'Digite sua nova senha',
-                      style: TextStyle(fontSize: 14, color: Color(0xFF9B9BB5)),
+                      style: TextStyle(fontSize: 14.sp, color: Color(0xFF9B9BB5)),
                     ),
-                    SizedBox(height: 40),
+                    SizedBox(height: 40.h),
                     TextFormField(
                       controller: _passwordController,
                       obscureText: !_showPassword,
@@ -135,7 +136,7 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
                         return null;
                       },
                     ),
-                    SizedBox(height: 16),
+                    SizedBox(height: 16.h),
                     TextFormField(
                       controller: _confirmPasswordController,
                       obscureText: !_showConfirmPassword,
@@ -160,15 +161,15 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
                         return null;
                       },
                     ),
-                    SizedBox(height: 16),
+                    SizedBox(height: 16.h),
                     Container(
                       width: double.infinity,
-                      height: 56,
+                      height: 56.h,
                       decoration: BoxDecoration(
                         gradient: LinearGradient(
                           colors: [Color(0xFF4A90D9), Color(0xFF7B2FBE)],
                         ),
-                        borderRadius: BorderRadius.circular(16),
+                        borderRadius: BorderRadius.circular(16.r),
                       ),
                       child: ElevatedButton(
                         onPressed: _resetPassword,
@@ -176,20 +177,20 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
                           backgroundColor: Colors.transparent,
                           shadowColor: Colors.transparent,
                           shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadiusGeometry.circular(16),
+                            borderRadius: BorderRadiusGeometry.circular(16.r),
                           ),
                         ),
                         child: Text(
                           'Salvar nova senha',
                           style: TextStyle(
-                            fontSize: 16,
+                            fontSize: 16.sp,
                             fontWeight: FontWeight.bold,
                             color: Colors.white,
                           ),
                         ),
                       ),
                     ),
-                    SizedBox(height: 32),
+                    SizedBox(height: 32.h),
                   ],
                 ),
               ),

--- a/lib/features/auth/screens/validate_otp_screen.dart
+++ b/lib/features/auth/screens/validate_otp_screen.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:kronos_app/features/auth/providers/auth_provider.dart';
 
 import 'package:kronos_app/features/auth/screens/reset_password_screen.dart';
@@ -68,7 +69,7 @@ class _ValidateOtpScreenState extends ConsumerState<ValidateOtpScreen> {
       body: SafeArea(
         child: SingleChildScrollView(
           child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 24),
+            padding: EdgeInsets.symmetric(horizontal: 24.w),
             child: SizedBox(
               width: double.infinity,
               child: Form(
@@ -80,18 +81,18 @@ class _ValidateOtpScreenState extends ConsumerState<ValidateOtpScreen> {
                     Text(
                       'VERIFICAR CÓDIGO',
                       style: TextStyle(
-                        fontSize: 28,
+                        fontSize: 28.sp,
                         fontWeight: FontWeight.bold,
                         letterSpacing: 4,
                       ),
                     ),
-                    SizedBox(height: 8),
+                    SizedBox(height: 8.h),
                     Text(
                       'Digite o código enviado para ${widget.email}',
                       textAlign: TextAlign.center,
-                      style: TextStyle(fontSize: 14, color: Color(0xFF9B9BB5)),
+                      style: TextStyle(fontSize: 14.sp, color: Color(0xFF9B9BB5)),
                     ),
-                    SizedBox(height: 40),
+                    SizedBox(height: 40.h),
                     TextFormField(
                       controller: _codeController,
                       keyboardType: TextInputType.number,
@@ -108,15 +109,15 @@ class _ValidateOtpScreenState extends ConsumerState<ValidateOtpScreen> {
                         return null;
                       },
                     ),
-                    SizedBox(height: 32),
+                    SizedBox(height: 32.h),
                     Container(
                       width: double.infinity,
-                      height: 56,
+                      height: 56.h,
                       decoration: BoxDecoration(
                         gradient: LinearGradient(
                           colors: [Color(0xFF4A90D9), Color(0xFF7B2FBE)],
                         ),
-                        borderRadius: BorderRadius.circular(16),
+                        borderRadius: BorderRadius.circular(16.r),
                       ),
                       child: ElevatedButton(
                         onPressed: _validateOtp,
@@ -124,20 +125,20 @@ class _ValidateOtpScreenState extends ConsumerState<ValidateOtpScreen> {
                           backgroundColor: Colors.transparent,
                           shadowColor: Colors.transparent,
                           shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadiusGeometry.circular(16),
+                            borderRadius: BorderRadiusGeometry.circular(16.r),
                           ),
                         ),
                         child: Text(
                           'Verificar código',
                           style: TextStyle(
-                            fontSize: 16,
+                            fontSize: 16.sp,
                             fontWeight: FontWeight.bold,
                             color: Colors.white,
                           ),
                         ),
                       ),
                     ),
-                    SizedBox(height: 32),
+                    SizedBox(height: 32.h),
                   ],
                 ),
               ),

--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
@@ -12,7 +13,7 @@ class HomeScreen extends ConsumerWidget {
           child: Text(
             'Bem-vindo ao Kronos!',
             style: TextStyle(
-              fontSize: 24,
+              fontSize: 24.sp,
               fontWeight: FontWeight.bold,
             ),
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 import 'core/theme/app_theme.dart';
 import 'package:kronos_app/features/auth/screens/login_screen.dart';
@@ -21,10 +22,17 @@ class MainApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      theme: AppTheme.dark,
-      home: const Scaffold(body: Center(child: LoginScreen())),
+    return ScreenUtilInit(
+      designSize: const Size(390, 844),
+      minTextAdapt: true,
+      splitScreenMode: true,
+      builder: (context, child) {
+        return MaterialApp(
+          debugShowCheckedModeBanner: false,
+          theme: AppTheme.dark,
+          home: LoginScreen(),
+        );
+      },
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -294,6 +294,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  flutter_screenutil:
+    dependency: "direct main"
+    description:
+      name: flutter_screenutil
+      sha256: "8239210dd68bee6b0577aa4a090890342d04a136ce1c81f98ee513fc0ce891de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.3"
   flutter_secure_storage:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   flutter_dotenv: ^6.0.0
   flutter_secure_storage: ^10.0.0
   flutter_web_auth_2: ^5.0.1
+  flutter_screenutil: ^5.9.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
feat: add responsiveness with flutter_screenutil

- Installed and configured flutter_screenutil
- Updated ScreenUtilInit in main.dart with designSize 390x844
- Updated all auth screens to use proportional values:
  - fontSize → .sp
  - height/width → .h/.w
  - padding → .w/.h
  - borderRadius → .r
- Screens updated:
  - login_screen.dart
  - register_screen.dart
  - forgot_password_screen.dart
  - validate_otp_screen.dart
  - reset_password_screen.dart
  - home_screen.dart