### PR TITLE
feat: add password recovery via Telegram screens

### DIFF
--- a/lib/features/auth/screens/forgot_password_screen.dart
+++ b/lib/features/auth/screens/forgot_password_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:kronos_app/features/auth/providers/auth_provider.dart';
 
 import 'package:kronos_app/features/auth/screens/validate_otp_screen.dart';
+import 'package:kronos_app/features/auth/screens/telegram_recovery_screen.dart';
 
 class ForgotPasswordScreen extends ConsumerStatefulWidget {
   const ForgotPasswordScreen({super.key});
@@ -40,7 +41,6 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
           builder: (context) => ValidateOtpScreen(email: _emailController.text),
         ),
       );
-
     } on DioException catch (err) {
       if (!mounted) return;
 
@@ -77,7 +77,10 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
                     SizedBox(height: 8.h),
                     Text(
                       'Digite seu email para receber o código',
-                      style: TextStyle(fontSize: 14.sp, color: Color(0xFF9B9BB5)),
+                      style: TextStyle(
+                        fontSize: 14.sp,
+                        color: Color(0xFF9B9BB5),
+                      ),
                     ),
                     SizedBox(height: 40.h),
                     TextFormField(
@@ -123,7 +126,26 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
                         ),
                       ),
                     ),
-                    SizedBox(height: 24.h),
+                    SizedBox(height: 16.h),
+                    GestureDetector(
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => TelegramRecoveryScreen(),
+                          ),
+                        );
+                      },
+                      child: Text(
+                        'Recuperar via Telegram? Clique aqui',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          color: Color(0xFF9B9BB5),
+                          fontSize: 13.sp,
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: 16.h),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [

--- a/lib/features/auth/screens/telegram_recovery_screen.dart
+++ b/lib/features/auth/screens/telegram_recovery_screen.dart
@@ -1,0 +1,231 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:kronos_app/features/auth/providers/auth_provider.dart';
+import 'package:kronos_app/features/auth/screens/reset_password_screen.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class TelegramRecoveryScreen extends ConsumerStatefulWidget {
+  const TelegramRecoveryScreen({super.key});
+
+  @override
+  ConsumerState<TelegramRecoveryScreen> createState() =>
+      _TelegramRecoveryScreenState();
+}
+
+class _TelegramRecoveryScreenState
+    extends ConsumerState<TelegramRecoveryScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _codeController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _codeController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _openTelegram() async {
+    final telegramUrl = Uri.parse('https://t.me/kronos_recovery_bot');
+    final playStoreUrl = Uri.parse(
+      'https://play.google.com/store/apps/details?id=org.telegram.messenger',
+    );
+
+    final launched = await launchUrl(
+      telegramUrl,
+      mode: LaunchMode.externalApplication,
+    );
+
+    if (!launched) {
+      await launchUrl(playStoreUrl, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  Future<void> _validateOtp() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    try {
+      final authService = ref.read(authServiceProvider);
+
+      await authService.validateOtp(
+        email: _emailController.text,
+        code: _codeController.text,
+      );
+
+      if (!mounted) return;
+
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) =>
+              ResetPasswordScreen(email: _emailController.text),
+        ),
+      );
+    } on DioException catch (err) {
+      if (!mounted) return;
+
+      final statusCode = err.response?.statusCode;
+      String message;
+      if (statusCode == 400) {
+        message = err.response?.data['message'] ?? 'Código inválido.';
+      } else {
+        message = 'Erro ao validar código.';
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message)),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 24.w),
+            child: SizedBox(
+              width: double.infinity,
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    SizedBox(height: MediaQuery.of(context).size.height * 0.10),
+                    Text(
+                      'RECUPERAR VIA TELEGRAM',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        fontSize: 24.sp,
+                        fontWeight: FontWeight.bold,
+                        letterSpacing: 4,
+                      ),
+                    ),
+                    SizedBox(height: 16.h),
+                    Text(
+                      '1. Abra o bot do Telegram\n2. Envie seu número de telefone cadastrado\n3. Você receberá um código de 6 dígitos\n4. Preencha seu email e o código abaixo',
+                      textAlign: TextAlign.left,
+                      style: TextStyle(
+                        fontSize: 14.sp,
+                        color: Color(0xFF9B9BB5),
+                        height: 1.8,
+                      ),
+                    ),
+                    SizedBox(height: 24.h),
+                    SizedBox(
+                      width: double.infinity,
+                      height: 56.h,
+                      child: OutlinedButton.icon(
+                        onPressed: _openTelegram,
+                        style: OutlinedButton.styleFrom(
+                          side: BorderSide(color: Color(0xFF2A2A4A)),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16.r),
+                          ),
+                        ),
+                        icon: Icon(
+                          Icons.telegram,
+                          color: Color(0xFF4A90D9),
+                        ),
+                        label: Text(
+                          'Abrir bot do Telegram',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 16.sp,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: 32.h),
+                    TextFormField(
+                      controller: _emailController,
+                      keyboardType: TextInputType.emailAddress,
+                      decoration: InputDecoration(hintText: 'Email'),
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'Email é obrigatório';
+                        }
+                        if (!value.contains('@') || !value.contains('.')) {
+                          return 'Email inválido';
+                        }
+                        return null;
+                      },
+                    ),
+                    SizedBox(height: 16.h),
+                    TextFormField(
+                      controller: _codeController,
+                      keyboardType: TextInputType.number,
+                      decoration: InputDecoration(
+                        hintText: 'Código de 6 dígitos',
+                      ),
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'Código é obrigatório';
+                        }
+                        if (value.length != 6) {
+                          return 'O código deve ter 6 dígitos';
+                        }
+                        return null;
+                      },
+                    ),
+                    SizedBox(height: 32.h),
+                    Container(
+                      width: double.infinity,
+                      height: 56.h,
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          colors: [Color(0xFF4A90D9), Color(0xFF7B2FBE)],
+                        ),
+                        borderRadius: BorderRadius.circular(16.r),
+                      ),
+                      child: ElevatedButton(
+                        onPressed: _validateOtp,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.transparent,
+                          shadowColor: Colors.transparent,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadiusGeometry.circular(16.r),
+                          ),
+                        ),
+                        child: Text(
+                          'Verificar código',
+                          style: TextStyle(
+                            fontSize: 16.sp,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: 24.h),
+                    GestureDetector(
+                      onTap: () => Navigator.pop(context),
+                      child: ShaderMask(
+                        shaderCallback: (bounds) => LinearGradient(
+                          colors: [Color(0xFF4A90D9), Color(0xFF7B2FBE)],
+                        ).createShader(bounds),
+                        child: Text(
+                          'Voltar',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 14.sp,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: 32.h),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -790,7 +790,7 @@ packages:
     source: hosted
     version: "1.4.0"
   url_launcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher
       sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   flutter_secure_storage: ^10.0.0
   flutter_web_auth_2: ^5.0.1
   flutter_screenutil: ^5.9.3
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
feat: password recovery via Telegram screens

- Added TelegramRecoveryScreen with step-by-step instructions
- Button to open Telegram bot directly from the app
- If Telegram not installed, redirects to Play Store
- Email and OTP code fields to validate recovery
- Reuses existing validate-otp and reset-password endpoints
- Added link "Prefere recuperar via Telegram?" on ForgotPasswordScreen
- Added url_launcher dependency